### PR TITLE
Fix spelling errors.

### DIFF
--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -40,7 +40,7 @@
   var PATH = MathJax.Ajax.config.path;
   if (!PATH.a11y) PATH.a11y =
       (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocal).match(/^https?:/) ? "" : "http:") + 
+      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
         "//cdn.mathjax.org/mathjax/contrib/a11y");
 
   var Accessibility = EXTENSIONS["accessibility-menu"] = {

--- a/extensions/auto-collapse.js
+++ b/extensions/auto-collapse.js
@@ -32,7 +32,7 @@
   var PATH = MathJax.Ajax.config.path;
   if (!PATH.a11y) PATH.a11y =
       (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocal).match(/^https?:/) ? "" : "http:") + 
+      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
         "//cdn.mathjax.org/mathjax/contrib/a11y");
 
   var Collapse = MathJax.Extension["auto-collapse"] = {

--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -40,7 +40,7 @@
   var PATH = MathJax.Ajax.config.path;
   if (!PATH.a11y) PATH.a11y =
       (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocal).match(/^https?:/) ? "" : "http:") + 
+      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
         "//cdn.mathjax.org/mathjax/contrib/a11y");
 
   var Collapsible = MathJax.Extension.collapsible = {

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -150,7 +150,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       if (MathJax.Menu) {
         var menu = MathJax.Menu.menu.FindId('Explorer');
         if (menu) {
-          var items = menu.submenu.items;
+          var items = (menu.submenu||menu.menu).items;
           for (var i = 2, item; item = items[i]; i++) item.disabled = state;
         }
       }
@@ -787,7 +787,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
 //
 if (!MathJax.Ajax.config.path.a11y) {
   MathJax.Ajax.config.path.a11y =
-      (String(location.protocal).match(/^https?:/) ? '' : 'http:') +
+      (String(location.protocol).match(/^https?:/) ? '' : 'http:') +
       '//cdn.mathjax.org/mathjax/contrib/a11y';
 }
 

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -150,7 +150,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       if (MathJax.Menu) {
         var menu = MathJax.Menu.menu.FindId('Explorer');
         if (menu) {
-          var items = (menu.submenu||menu.menu).items;
+          var items = menu.submenu.items;
           for (var i = 2, item; item = items[i]; i++) item.disabled = state;
         }
       }

--- a/extensions/semantic-enrich.js
+++ b/extensions/semantic-enrich.js
@@ -95,7 +95,7 @@ MathJax.Extension["semantic-enrich"] = {
   var PATH = MathJax.Ajax.config.path;
   if (!PATH.a11y) PATH.a11y =
       (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocal).match(/^https?:/) ? "" : "http:") + 
+      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
         "//cdn.mathjax.org/mathjax/contrib/a11y");
 
   //


### PR DESCRIPTION
This fixes my dopy-and-pasted spelling error in "protocol".  I thought I remembered Peter already doing that, but it seems not to be fixed, so I'm submitting this pull request to do so.