### PR TITLE
Move accessibility menu items to a submenu

### DIFF
--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -72,6 +72,13 @@
         items.unshift(ITEM.RULE());
         menu.submenu.items.push.apply(menu.submenu.items,items);
       } else {
+        var renderer = (MENU.FindId("Settings","Renderer")||{}).submenu;
+        if (renderer) {
+          // move AssitiveMML and InTabOrder from Renderer to Accessibility menu
+          items.unshift(ITEM.RULE());
+          items.unshift(renderer.items.pop());
+          items.unshift(renderer.items.pop());
+        }
         items.unshift("Accessibility");
         var menu = ITEM.SUBMENU.apply(ITEM.SUBMENU,items);
         var locale = MENU.IndexOfId('Locale');

--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -67,14 +67,19 @@
     AddMenu: function() {
       var items = Array(this.modules.length);
       for (var i = 0, module; module = this.modules[i]; i++) items[i] = module.placeHolder;
-      var about = MENU.IndexOfId('About');
-      if (about === null) {
+      var menu = MENU.FindId('Accessibility');
+      if (menu) {
         items.unshift(ITEM.RULE());
-        MENU.items.push.apply(MENU.items, items);
+        menu.submenu.items.push.apply(menu.submenu.items,items);
       } else {
-        items.push(ITEM.RULE());
-        items.unshift(about, 0);
-        MENU.items.splice.apply(MENU.items, items);
+        items.unshift("Accessibility");
+        var menu = ITEM.SUBMENU.apply(ITEM.SUBMENU,items);
+        var locale = MENU.IndexOfId('Locale');
+        if (locale) {
+          MENU.items.splice(locale,0,menu);
+        } else {
+          MENU.items.push(ITEM.RULE(), menu);
+        }
       }
     },
     Register: function(module) {

--- a/extensions/auto-collapse.js
+++ b/extensions/auto-collapse.js
@@ -335,9 +335,15 @@
       var menu = ITEM.CHECKBOX(
         ['AutoCollapse','Auto Collapse'], 'autocollapse', {action: Switch}
       );
-      var index = MENU.IndexOfId('AutoCollapse');
-      if (index !== null) {
-        MENU.items[index] = menu;
+      var submenu = (MENU.FindId('Accessibility')||{}).submenu, index;
+      if (submenu) {
+        index = submenu.IndexOfId('AutoCollapse');
+        if (index !== null) {
+          submenu.items[index] = menu;
+        } else {
+          index = submenu.IndexOfId('CollapsibleMath');
+          submenu.items.splice(index+1,0,menu);
+        }
       } else {
         index = MENU.IndexOfId('CollapsibleMath');
         MENU.items.splice(index+1,0,menu);

--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -474,9 +474,14 @@
       var menu = ITEM.CHECKBOX(
         ['CollapsibleMath','Collapsible Math'], 'collapsible', {action: Switch}
       );
-      var index = MENU.IndexOfId('CollapsibleMath');
-      if (index !== null) {
-        MENU.items[index] = menu;
+      var submenu = (MENU.FindId('Accessibility')||{}).submenu, index;
+      if (submenu) {
+        index = submenu.IndexOfId('CollapsibleMath');
+        if (index !== null) {
+          submenu.items[index] = menu;
+        } else {
+          submenu.items.push(ITEM.RULE(),menu);
+        }
       } else {
         index = MENU.IndexOfId('About');
         MENU.items.splice(index,0,menu,ITEM.RULE());

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -752,12 +752,18 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                              'Assistive-ruleset', speech)
               )
           );
-      var box = MENU.IndexOfId('Explorer');
-      if (box !== null) {
-        MENU.items[box] = explorerMenu;
+      var submenu = (MENU.FindId('Accessibility')||{}).submenu, index;
+      if (submenu) {
+        index = submenu.IndexOfId('Explorer');
+        if (index !== null) {
+          submenu.items[index] = explorerMenu;
+        } else {
+          index = submenu.IndexOfId('CollapsibleMath');
+          submenu.items.splice(index+1,0,explorerMenu);
+        }
       } else {
-        var index = MENU.IndexOfId('CollapsibleMath');
-        MENU.items.splice(index + 1, 0, explorerMenu);
+        index = MENU.IndexOfId('CollapsibleMath');
+        MENU.items.splice(index+1,0,explorerMenu);
       }
       if (!SETTINGS.explorer) Assistive.DisableMenus(true);
     },20);  // Between collapsible and auto-collapse extensions

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -752,18 +752,18 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                              'Assistive-ruleset', speech)
               )
           );
-      var submenu = (MENU.FindId('Accessibility')||{}).submenu, index;
+      var submenu = (MENU.FindId('Accessibility') || {}).submenu, index;
       if (submenu) {
         index = submenu.IndexOfId('Explorer');
         if (index !== null) {
           submenu.items[index] = explorerMenu;
         } else {
           index = submenu.IndexOfId('CollapsibleMath');
-          submenu.items.splice(index+1,0,explorerMenu);
+          submenu.items.splice(index + 1, 0, explorerMenu);
         }
       } else {
         index = MENU.IndexOfId('CollapsibleMath');
-        MENU.items.splice(index+1,0,explorerMenu);
+        MENU.items.splice(index + 1, 0, explorerMenu);
       }
       if (!SETTINGS.explorer) Assistive.DisableMenus(true);
     },20);  // Between collapsible and auto-collapse extensions


### PR DESCRIPTION
This PR makes a change that I'm proposing to be included in 2.7 that moves the accessibility menu items to an accessibility submenu rather than putting them in the main menu.  This makes the accessibility settings work like the Math Settings, and doesn't clutter the main menu so much.  This would include a change to the MathMenu.js file to create the initial Accessibility submenu, and would move the "Assistive MathML" and "Include in Tab Order" menu items from the Renderer submenu to the Accessibility menu, so the menu is always populated with something, even if the accessibility-menu extension isn't loaded.  The extension then adds the three new items to that menu when it *is* loaded.

Here is how it looks:

<img width="564" alt="menu" src="https://cloud.githubusercontent.com/assets/432782/18286460/ecabb2f4-7440-11e6-86f4-2748e15b58b3.png">

It still works with v2.6; the extension will create the Accessibility menu item itself and move the two existing items to it automatically.  (In 2.6, if the accessibility-menu extension isn't loaded, but the individual extensions are, then they will add their items to the main menu, as they do now.)

If you don't like the idea of the accessibility menu always being there, then we could leave the AccessibleMML and InTabOrder items in their current places, and the extension would make the new submenu (and move the two items) automatically.  But I think it may be better to have the accessible menu all the time, as I never really thought those two items fit as well in the renderer menu anyway.

In any case, I think it is worth moving the new accessibility items to a submenu.  What do you think?