### PR TITLE
Make sure FindChildText() uses the core mo

### DIFF
--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -302,7 +302,7 @@
     //
     FindChildText: function (mml,id) {
       var child = this.FindChild(mml,id);
-      return (child ? child.data.join("") : "?");
+      return (child ? (child.CoreMO()||child).data.join("") : "?");
     },
     FindChild: function (mml,id) {
       if (mml) {


### PR DESCRIPTION
Make sure FindChildText() uses the core mo, if there is one.  This makes sure that the collapsed marker uses the text of the core element rather than tries to use the nested MathML for embellished operators.

Resolves issue #163.