### PR TITLE
Update for change in cdn

### DIFF
--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -38,10 +38,7 @@
   //  Set up the a11y path,if it isn't already in place
   //
   var PATH = MathJax.Ajax.config.path;
-  if (!PATH.a11y) PATH.a11y =
-      (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
-        "//cdn.mathjax.org/mathjax/contrib/a11y");
+  if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   var Accessibility = EXTENSIONS["accessibility-menu"] = {
     version: '1.1',

--- a/extensions/auto-collapse.js
+++ b/extensions/auto-collapse.js
@@ -30,10 +30,7 @@
   //  Set up the a11y path,if it isn't already in place
   //
   var PATH = MathJax.Ajax.config.path;
-  if (!PATH.a11y) PATH.a11y =
-      (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
-        "//cdn.mathjax.org/mathjax/contrib/a11y");
+  if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   var Collapse = MathJax.Extension["auto-collapse"] = {
     version: "1.1",

--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -38,10 +38,7 @@
   //  Set up the a11y path,if it isn't already in place
   //
   var PATH = MathJax.Ajax.config.path;
-  if (!PATH.a11y) PATH.a11y =
-      (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
-        "//cdn.mathjax.org/mathjax/contrib/a11y");
+  if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   var Collapsible = MathJax.Extension.collapsible = {
     version: "1.1",

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -793,9 +793,7 @@ MathJax.Hub.Register.StartupHook("SVG Jax Ready",function () {
 //  Set up the a11y path,if it isn't already in place
 //
 if (!MathJax.Ajax.config.path.a11y) {
-  MathJax.Ajax.config.path.a11y =
-      (String(location.protocol).match(/^https?:/) ? '' : 'http:') +
-      '//cdn.mathjax.org/mathjax/contrib/a11y';
+  MathJax.Ajax.config.path.a11y = MathJax.Hub.config.root + "/extensions/a11y";
 }
 
 MathJax.Ajax.Require('[a11y]/collapsible.js');

--- a/extensions/semantic-enrich.js
+++ b/extensions/semantic-enrich.js
@@ -93,10 +93,7 @@ MathJax.Extension["semantic-enrich"] = {
   //  Set up the a11y path,if it isn't already in place
   //
   var PATH = MathJax.Ajax.config.path;
-  if (!PATH.a11y) PATH.a11y =
-      (PATH.Contrib ? PATH.Contrib + "/a11y" : 
-      (String(location.protocol).match(/^https?:/) ? "" : "http:") + 
-        "//cdn.mathjax.org/mathjax/contrib/a11y");
+  if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   //
   //  Load SRE and use the signal to tell MathJax when it is loaded.


### PR DESCRIPTION
Update to use copy in extensions if there is no a11y path specified.

After this is merged, we need to run grunt, and move the resulting files into the MathJax repo in the `extensions/a11y` directory 