### PR TITLE
Fix accessibility-menu to work as part of a combined config file. #197.

### DIFF
--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -98,7 +98,7 @@
     },
     LoadExtensions: function () {
       var extensions = [];
-      for (var i = 0, mpdule; module = this.modules[i]; i++) {
+      for (var i = 0, module; module = this.modules[i]; i++) {
         if (SETTINGS[module.option]) extensions.push(module.module);
       }
       return (extensions.length ? HUB.Startup.loadArray(extensions) : null);
@@ -172,10 +172,12 @@
     },5);   // run before other extensions' menu hooks even if they are loaded first
   },5);
   
-  MathJax.Callback.Queue(
-    ["LoadExtensions",Accessibility],
-    ["loadComplete",MathJax.Ajax,"[a11y]/accessibility-menu.js"]
-  );
+  MathJax.Hub.Register.StartupHook("End Cookie", function () {
+    MathJax.Callback.Queue(
+      ["LoadExtensions",Accessibility],
+      ["loadComplete",MathJax.Ajax,"[a11y]/accessibility-menu.js"]
+    );
+  });
 
 })(MathJax.Hub,MathJax.Extension);
 


### PR DESCRIPTION
This fixes issue #197, a timing problem when accessibility-menu is included explicitly in a combined configuration file (which did not occur in MathJax prior to 2.7.1).  In 2.7.0, only a *reference* to it was included, and it was loaded from the contrib repository.

We should probably start a `develop` branch for this repo.  Then this PR should be retargeted at that branch.

