### PR TITLE
Don't use default as a property name (for IE8 and below).

### DIFF
--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -43,7 +43,7 @@
   var Accessibility = EXTENSIONS["accessibility-menu"] = {
     version: '1.2.2',
     prefix: '', //'Accessibility-',
-    default: {},
+    defaults: {},
     modules: [],
     MakeOption: function(name) {
       return Accessibility.prefix + name;
@@ -52,11 +52,11 @@
       return SETTINGS[Accessibility.MakeOption(option)];
     },
     AddDefaults: function() {
-      var keys = KEYS(Accessibility.default);
+      var keys = KEYS(Accessibility.defaults);
       for (var i = 0, key; key = keys[i]; i++) {
         var option = Accessibility.MakeOption(key);
         if (typeof(SETTINGS[option]) === 'undefined') {
-          SETTINGS[option] = Accessibility.default[key];
+          SETTINGS[option] = Accessibility.defaults[key];
         }
       }
     },
@@ -87,7 +87,7 @@
       }
     },
     Register: function(module) {
-      Accessibility.default[module.option] = false;
+      Accessibility.defaults[module.option] = false;
       Accessibility.modules.push(module);
     },
     Startup: function() {

--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -94,7 +94,7 @@
       punctuated: {
         endpunct: NOCOLLAPSE,
         startpunct: NOCOLLAPSE,
-        default: 12
+        value: 12
       }
     },
     //
@@ -108,7 +108,7 @@
       text: "...",
       appl: {
         "limit function": "lim",
-        default: "f()"
+        value: "f()"
       },
       fraction: "/",
       sqrt: "\u221A",
@@ -119,14 +119,14 @@
       vector: {
         binomial: "(:)",
         determinant: "|:|",
-        default: "\u27E8:\u27E9"
+        value: "\u27E8:\u27E9"
       },
       matrix: {
         squarematrix: "[::]",
         rowvector: "\u27E8\u22EF\u27E9",
         columnvector: "\u27E8\u22EE\u27E9",
         determinant: "|::|",
-        default: "(::)"
+        value: "(::)"
       },
       cases: "{:",
       infixop: {
@@ -134,11 +134,11 @@
         subtraction: "\u2212",
         multiplication: "\u22C5",
         implicit: "\u22C5",
-        default: "+"
+        value: "+"
       },
       punctuated: {
         text: "...",
-        default: ","
+        value: ","
       }
     },
 
@@ -265,10 +265,10 @@
         else if (this.COLLAPSE[type] && this.MARKER[type]) {
           var role = mml.attr["data-semantic-role"];
           var complexity = this.COLLAPSE[type];
-          if (typeof(complexity) !== "number") complexity = complexity[role] || complexity.default;
+          if (typeof(complexity) !== "number") complexity = complexity[role] || complexity.value;
           if (mml.complexity > complexity) {
             var marker = this.MARKER[type];
-            if (typeof(marker) !== "string") marker = marker[role] || marker.default;
+            if (typeof(marker) !== "string") marker = marker[role] || marker.value;
             mml = this.MakeAction(this.Marker(marker),mml);
           }
         }
@@ -348,7 +348,7 @@
     Collapse_appl: function (mml) {
       if (this.UncollapseChild(mml,2,2)) {
         var marker = this.MARKER.appl;
-        marker = marker[mml.attr["data-semantic-role"]] || marker.default;
+        marker = marker[mml.attr["data-semantic-role"]] || marker.value;
         mml = this.MakeAction(this.Marker(marker),mml);
       }
       return mml;

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -37,7 +37,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     //
     // Default configurations.
     //
-    default: {
+    defaults: {
       walker: 'syntactic',
       highlight: 'none',
       background: 'blue',
@@ -56,7 +56,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     },
 
     addDefaults: function() {
-      var defaults = MathJax.Hub.CombineConfig('explorer', Assistive.default);
+      var defaults = MathJax.Hub.CombineConfig('explorer', Assistive.defaults);
       var keys = Object.keys(defaults);
       for (var i = 0, key; key = keys[i]; i++) {
         if (typeof(SETTINGS[Assistive.prefix + key]) === 'undefined') {


### PR DESCRIPTION
This PR changes the occurrences of `default` as a property name to another name, since "default" used to be a reserved word, and it causes IE8 and below to fail when loading the accessibility-menu extension.

Resolves issue #202.