### PR TITLE
Properly set parents of nodes moved into an maction. #210

### DIFF
--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -224,10 +224,10 @@
       maction.attr[COMPLEXATTR] = maction.complexity;
       if (mml.type === "math") {
         var mrow = MML.mrow().With({
-          data: mml.data,
           complexity: mml.complexity,
           attrNames: [], attr: {}
         });
+        mrow.Append.apply(mrow,mml.data);
         for (var i = mml.attrNames.length-1, name; name = mml.attrNames[i]; i--) {
           if (name.substr(0,14) === "data-semantic-") {
             mrow.attr[name] = mml.attr[name];


### PR DESCRIPTION
Make sure the elements moved to an `<maction>` that is the immediate child of the `<math>` node have the correct parent elements.

Resolves issue #210.