### PR TITLE
Don't add duplicate xmlns entry if original is blank.

### DIFF
--- a/extensions/semantic-enrich.js
+++ b/extensions/semantic-enrich.js
@@ -143,7 +143,7 @@ MathJax.Callback.Queue(
             lookup = (ENRICH.running ? ENRICH.mstyleLookup[this.type]||[] : []);
         var attr = [], ATTR = (this.attr||{});
 
-        if (this.type === "math" && (!this.attr || !this.attr.xmlns))
+        if (this.type === "math" && (!this.attr || !('xmlns' in this.attr)))
           attr.push('xmlns="http://www.w3.org/1998/Math/MathML"');
         if (!this.attrNames) {
           for (var id in defaults) {if (!skip[id] && !copy[id] && defaults.hasOwnProperty(id)) {


### PR DESCRIPTION
Don't add duplicate `xmlns` entry if original exists but is blank.  This prevents SRE from crashing due to duplicate attributes.

Resolves issue #220.