### PR TITLE
Upgrade a11y extension to work with latest SRE

### DIFF
--- a/extensions/accessibility-menu.js
+++ b/extensions/accessibility-menu.js
@@ -41,7 +41,7 @@
   if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   var Accessibility = EXTENSIONS["accessibility-menu"] = {
-    version: '1.5.0',
+    version: '1.6.0',
     prefix: '', //'Accessibility-',
     defaults: {},
     modules: [],

--- a/extensions/auto-collapse.js
+++ b/extensions/auto-collapse.js
@@ -33,7 +33,7 @@
   if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   var Collapse = MathJax.Extension["auto-collapse"] = {
-    version: "1.5.0",
+    version: "1.6.0",
     config: HUB.CombineConfig("auto-collapse",{
       disabled: false
     }),

--- a/extensions/collapsible.js
+++ b/extensions/collapsible.js
@@ -41,7 +41,7 @@
   if (!PATH.a11y) PATH.a11y = HUB.config.root + "/extensions/a11y";
 
   var Collapsible = MathJax.Extension.collapsible = {
-    version: "1.5.0",
+    version: "1.6.0",
     config: HUB.CombineConfig("collapsible",{
       disabled: false
     }),

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -610,6 +610,10 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
             Explorer.Walkers['none'];
       var speechGenerator = speechOn ? new sre.DirectSpeechGenerator() :
           new sre.DummySpeechGenerator();
+      var options = sre.System.getInstance().engineSetup();
+      speechGenerator.setOptions({
+        locale: options.locale, domain: options.domain,
+        style: options.style, modality: 'speech'});
       Explorer.GetHighlighter(.2);
       Explorer.walker = new constructor(
           math, speechGenerator, Explorer.highlighter, jax.root.toMathML());

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -217,7 +217,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       }
     }
   }, {
-    ANNOUNCE: 'Navigatable Math in page. Explore with shift space and arrow' +
+    ANNOUNCE: 'Navigatable Math in page. Explore with enter or shift space and arrow' +
         ' keys. Expand or collapse elements hitting enter.',
     announced: false,
     added: false,

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -90,8 +90,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       sre.System.getInstance().setupEngine({
         locale: MathJax.Localization.locale,
         domain: Assistive.Domain(cstr[0]),
-        style: cstr[1],
-        rules: Assistive.RuleSet(cstr[0])
+        style: cstr[1]
       });
       Assistive.oldrules = ruleset;
     },
@@ -100,20 +99,11 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       switch (domain) {
         case 'chromevox':
           return 'default';
+        case 'clearspeak':
+          return 'clearspeak';
         case 'mathspeak':
         default:
           return 'mathspeak';
-      }
-    },
-
-    RuleSet: function(domain) {
-      switch (domain) {
-        case 'chromevox':
-          return ['AbstractionRules', 'SemanticTreeRules'];
-        case 'mathspeak':
-        default:
-          return ['AbstractionRules', 'AbstractionSpanish',
-                  'MathspeakRules', 'MathspeakSpanish'];
       }
     },
 
@@ -482,8 +472,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     //
     Keydown: function(event) {
       var code = event.keyCode;
-      // Maps the return key to dash for SRE v3.
-      code = code === KEY.RETURN ? 189 : code;
       if (code === KEY.ESCAPE) {
         if (!Explorer.walker) return;
         Explorer.RemoveHook();
@@ -493,6 +481,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       }
       // If walker is active we redirect there.
       if (Explorer.walker && Explorer.walker.isActive()) {
+        // Maps the return key to dash for SRE v3.
+        code = code === KEY.RETURN ? KEY.DASH : code;
         if (typeof(Explorer.walker.modifier) !== 'undefined') {
           Explorer.walker.modifier = event.shiftKey;
         }
@@ -637,6 +627,10 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Deactivates the walker.
     //
     DeactivateWalker: function() {
+      var setup = sre.System.getInstance().engineSetup();
+      var domain = setup.domain;
+      var style = domain === 'clearspeak' ? 'default' : setup.style;
+      Assistive.setOption('ruleset', setup.domain + '-' + style);
       Explorer.liveRegion.Clear();
       Explorer.liveRegion.Hide();
       Explorer.Unhighlight();
@@ -769,11 +763,11 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                   ITEM.RADIO(['mathspeak-sbrief', 'Superbrief'],
                              'Assistive-ruleset', speech)
               ),
+              ITEM.RADIO(['clearspeak-default', 'Clearspeak Rules'],
+                         'Assistive-ruleset', speech),
               ITEM.SUBMENU(['Chromevox', 'ChromeVox Rules'],
                   ITEM.RADIO(['chromevox-default', 'Verbose'],
                              'Assistive-ruleset', speech),
-                  ITEM.RADIO(['chromevox-short', 'Short'], 'Assistive-ruleset',
-                             speech),
                   ITEM.RADIO(['chromevox-alternative', 'Alternative'],
                              'Assistive-ruleset', speech)
               )

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -481,7 +481,10 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Event execution on keydown. Subsumes the same method of MathEvents.
     //
     Keydown: function(event) {
-      if (event.keyCode === KEY.ESCAPE) {
+      var code = event.keyCode;
+      // Maps the return key to dash for SRE v3.
+      code = code === KEY.RETURN ? 189 : code;
+      if (code === KEY.ESCAPE) {
         if (!Explorer.walker) return;
         Explorer.RemoveHook();
         Explorer.DeactivateWalker();
@@ -493,7 +496,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
         if (typeof(Explorer.walker.modifier) !== 'undefined') {
           Explorer.walker.modifier = event.shiftKey;
         }
-        var move = Explorer.walker.move(event.keyCode);
+        var move = Explorer.walker.move(code);
         if (move === null) return;
         if (move) {
           if (Explorer.walker.moved === 'expand') {
@@ -519,7 +522,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
         return;
       }
       var math = event.target;
-      if (event.keyCode === KEY.SPACE) {
+      if (code === KEY.SPACE) {
         if (event.shiftKey && Assistive.hook) {
           var jax = MathJax.Hub.getJaxFor(math);
           Explorer.ActivateWalker(math, jax);

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -324,7 +324,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       var oldJax = Explorer.jaxCache[id];
       if (oldJax && oldJax === jax.root) return;
       if (oldJax) {
-        Explorer.highlighter.resetState(id + '-Frame');
+        sre.Walker.resetState(id + '-Frame');
       }
       Explorer.jaxCache[id] = jax.root;
     },
@@ -436,8 +436,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     },
     AddSpeechLazy: function(math) {
       var generator = new sre.TreeSpeechGenerator();
-      generator.setRebuilt(Explorer.walker.rebuilt);
-      generator.getSpeech(Explorer.walker.rootNode, Explorer.walker.xml);
+      generator.setRebuilt(Explorer.walker.getRebuilt());
+      generator.getSpeech(Explorer.walker.rootNode, Explorer.walker.getXml());
       math.setAttribute('hasspeech', 'true');
     },
     //

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -32,7 +32,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   });
 
   var Assistive = MathJax.Extension.explorer = {
-    version: '1.5.0',
+    version: '1.6.0',
     dependents: [],            // the extensions that depend on this one
     //
     // Default configurations.

--- a/extensions/explorer.js
+++ b/extensions/explorer.js
@@ -512,14 +512,16 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
         return;
       }
       var math = event.target;
-      if (code === KEY.SPACE) {
-        if (event.shiftKey && Assistive.hook) {
+      if (code === KEY.SPACE && !event.shiftKey) {
+        MathJax.Extension.MathEvents.Event.ContextMenu(event, math);
+        FALSE(event);
+        return;
+      }
+      if (Assistive.hook && (code === KEY.RETURN ||
+                             (code === KEY.SPACE && event.shiftKey))) {
           var jax = MathJax.Hub.getJaxFor(math);
           Explorer.ActivateWalker(math, jax);
           Explorer.AddHook(jax);
-        } else {
-          MathJax.Extension.MathEvents.Event.ContextMenu(event, math);
-        }
         FALSE(event);
         return;
       }

--- a/extensions/semantic-enrich.js
+++ b/extensions/semantic-enrich.js
@@ -23,7 +23,7 @@
  */
 
 MathJax.Extension["semantic-enrich"] = {
-  version: "1.5.0",
+  version: "1.6.0",
   config: MathJax.Hub.CombineConfig("semantic-enrich",{disabled: false}),
   dependents: [],     // the extensions that depend on this one
   running: false,


### PR DESCRIPTION
Adapts the code to work with the latest version of SRE. __Note, that this is not backward compatible and will only work with SRE >=3.0__

In detail it: 
* Converts to the lazy computation of walkers (unfortunately SRE does not use getters o/w this would be compatible).
* Maps old collapse key `Return` to new key `-`.
* Enables the keyboard cycling of rule sets, and thus allows the use of Clearspeak in v2. Now we do not have facilities to update the menu as well, thus menu and speech rule set settings can get out of sync. This is the final commit, we can leave it off if you don't think that is a good idea.

